### PR TITLE
Refactor AJAX handling and sanitize dashboard output

### DIFF
--- a/admin/class-eos-admin.php
+++ b/admin/class-eos-admin.php
@@ -30,4 +30,3 @@ class EOS_Admin {
         }
     }
 }
-?>

--- a/admin/views/dashboard.php
+++ b/admin/views/dashboard.php
@@ -97,17 +97,29 @@ $upcoming_meetings = EOS_Meetings::get_upcoming(1);
                     <?php _e('Schedule', 'eos-manager'); ?> →
                 </a>
             </div>
-            <?php if (!empty($upcoming_meetings)): ?>
+            <?php if (!empty($upcoming_meetings)) : ?>
                 <div class="eos-next-meeting">
                     <?php
                     $next_meeting = $upcoming_meetings[0];
-                    $meeting_date = new DateTime($next_meeting['meeting_date']);
-                    printf(
-                        __('Next: %s', 'eos-manager'),
-                        $meeting_date->format('l g:i A - ') . esc_html($next_meeting['title'])
-                    );
+                    if (!empty($next_meeting['meeting_date'])) {
+                        try {
+                            $meeting_date = new DateTime($next_meeting['meeting_date']);
+                            printf(
+                                esc_html__('Next: %s', 'eos-manager'),
+                                $meeting_date->format('l g:i A - ') . esc_html($next_meeting['title'])
+                            );
+                            echo ' <span class="eos-google-meet-badge">📹 Meet</span>';
+                        } catch (Exception $e) {
+                            esc_html_e('Next meeting date unavailable.', 'eos-manager');
+                        }
+                    } else {
+                        esc_html_e('No upcoming meetings scheduled.', 'eos-manager');
+                    }
                     ?>
-                    <span class="eos-google-meet-badge">📹 Meet</span>
+                </div>
+            <?php else : ?>
+                <div class="eos-next-meeting">
+                    <?php esc_html_e('No upcoming meetings scheduled.', 'eos-manager'); ?>
                 </div>
             <?php endif; ?>
             <div class="eos-card-preview">
@@ -465,4 +477,3 @@ add_action('admin_footer', function() {
     </style>
     <?php
 });
-?>

--- a/admin/views/dashboard.php
+++ b/admin/views/dashboard.php
@@ -28,10 +28,10 @@ $upcoming_meetings = EOS_Meetings::get_upcoming(1);
                 </div>
             </div>
             <div class="eos-quick-actions">
-                <a href="<?php echo admin_url('admin.php?page=eos-meetings&action=start'); ?>" class="eos-action-btn primary">
+                <a href="<?php echo esc_url(admin_url('admin.php?page=eos-meetings&action=start')); ?>" class="eos-action-btn primary">
                     <?php _e('Start L10 Meeting', 'eos-manager'); ?>
                 </a>
-                <a href="<?php echo admin_url('admin.php?page=eos-scorecard'); ?>" class="eos-action-btn">
+                <a href="<?php echo esc_url(admin_url('admin.php?page=eos-scorecard')); ?>" class="eos-action-btn">
                     <?php _e('Weekly Review', 'eos-manager'); ?>
                 </a>
                 <a href="#" class="eos-action-btn" onclick="openModal('addRockModal')">
@@ -45,27 +45,27 @@ $upcoming_meetings = EOS_Meetings::get_upcoming(1);
     <div class="eos-dashboard-grid">
         
         <!-- Rocks Card -->
-        <div class="eos-dashboard-card" onclick="location.href='<?php echo admin_url('admin.php?page=eos-rocks'); ?>'">
+        <div class="eos-dashboard-card" onclick="location.href='<?php echo esc_url(admin_url('admin.php?page=eos-rocks')); ?>'">
             <div class="eos-card-header">
                 <div class="eos-card-title">
                     <div class="eos-card-icon rocks">🎯</div>
                     <span><?php _e('90-Day Rocks', 'eos-manager'); ?></span>
                 </div>
-                <a href="<?php echo admin_url('admin.php?page=eos-rocks'); ?>" class="eos-card-action">
+                <a href="<?php echo esc_url(admin_url('admin.php?page=eos-rocks')); ?>" class="eos-card-action">
                     <?php _e('View All', 'eos-manager'); ?> →
                 </a>
             </div>
             <div class="eos-card-stats">
                 <div class="eos-stat-item">
-                    <span class="eos-stat-number"><?php echo $rocks_stats['on_track']; ?></span>
+                    <span class="eos-stat-number"><?php echo esc_html($rocks_stats['on_track']); ?></span>
                     <span class="eos-stat-label"><?php _e('On Track', 'eos-manager'); ?></span>
                 </div>
                 <div class="eos-stat-item">
-                    <span class="eos-stat-number"><?php echo $rocks_stats['at_risk']; ?></span>
+                    <span class="eos-stat-number"><?php echo esc_html($rocks_stats['at_risk']); ?></span>
                     <span class="eos-stat-label"><?php _e('At Risk', 'eos-manager'); ?></span>
                 </div>
                 <div class="eos-stat-item">
-                    <span class="eos-stat-number"><?php echo $rocks_stats['behind']; ?></span>
+                    <span class="eos-stat-number"><?php echo esc_html($rocks_stats['behind']); ?></span>
                     <span class="eos-stat-label"><?php _e('Behind', 'eos-manager'); ?></span>
                 </div>
             </div>
@@ -76,8 +76,8 @@ $upcoming_meetings = EOS_Meetings::get_upcoming(1);
                     printf(
                         __('Most urgent: "%s" (%d%% complete, due in %d days)', 'eos-manager'),
                         esc_html($urgent_rock['title']),
-                        $urgent_rock['progress'],
-                        $urgent_rock['days_remaining']
+                        intval($urgent_rock['progress']),
+                        intval($urgent_rock['days_remaining'])
                     );
                 } else {
                     _e('No active rocks found. Time to set some priorities!', 'eos-manager');
@@ -93,7 +93,7 @@ $upcoming_meetings = EOS_Meetings::get_upcoming(1);
                     <div class="eos-card-icon meetings">📅</div>
                     <span><?php _e('L10 Meetings', 'eos-manager'); ?></span>
                 </div>
-                <a href="<?php echo admin_url('admin.php?page=eos-meetings'); ?>" class="eos-card-action">
+                <a href="<?php echo esc_url(admin_url('admin.php?page=eos-meetings')); ?>" class="eos-card-action">
                     <?php _e('Schedule', 'eos-manager'); ?> →
                 </a>
             </div>
@@ -116,23 +116,23 @@ $upcoming_meetings = EOS_Meetings::get_upcoming(1);
         </div>
 
         <!-- Scorecard Card -->
-        <div class="eos-dashboard-card" onclick="location.href='<?php echo admin_url('admin.php?page=eos-scorecard'); ?>'">
+        <div class="eos-dashboard-card" onclick="location.href='<?php echo esc_url(admin_url('admin.php?page=eos-scorecard')); ?>'">
             <div class="eos-card-header">
                 <div class="eos-card-title">
                     <div class="eos-card-icon scorecard">📊</div>
                     <span><?php _e('Company Scorecard', 'eos-manager'); ?></span>
                 </div>
-                <a href="<?php echo admin_url('admin.php?page=eos-scorecard'); ?>" class="eos-card-action">
+                <a href="<?php echo esc_url(admin_url('admin.php?page=eos-scorecard')); ?>" class="eos-card-action">
                     <?php _e('Update', 'eos-manager'); ?> →
                 </a>
             </div>
             <div class="eos-card-stats">
                 <div class="eos-stat-item">
-                    <span class="eos-stat-number"><?php echo $scorecard_stats['health_percentage']; ?>%</span>
+                    <span class="eos-stat-number"><?php echo esc_html($scorecard_stats['health_percentage']); ?>%</span>
                     <span class="eos-stat-label"><?php _e('Health', 'eos-manager'); ?></span>
                 </div>
                 <div class="eos-stat-item">
-                    <span class="eos-stat-number"><?php echo $scorecard_stats['on_target']; ?>/<?php echo $scorecard_stats['total']; ?></span>
+                    <span class="eos-stat-number"><?php echo esc_html($scorecard_stats['on_target']); ?>/<?php echo esc_html($scorecard_stats['total']); ?></span>
                     <span class="eos-stat-label"><?php _e('On Target', 'eos-manager'); ?></span>
                 </div>
             </div>
@@ -141,7 +141,7 @@ $upcoming_meetings = EOS_Meetings::get_upcoming(1);
                 if ($scorecard_stats['behind'] > 0) {
                     printf(
                         __('%d metrics behind target this week.', 'eos-manager'),
-                        $scorecard_stats['behind']
+                        intval($scorecard_stats['behind'])
                     );
                 } else {
                     _e('All metrics on or above target this week!', 'eos-manager');
@@ -151,23 +151,23 @@ $upcoming_meetings = EOS_Meetings::get_upcoming(1);
         </div>
 
         <!-- Issues List Card -->
-        <div class="eos-dashboard-card" onclick="location.href='<?php echo admin_url('admin.php?page=eos-issues'); ?>'">
+        <div class="eos-dashboard-card" onclick="location.href='<?php echo esc_url(admin_url('admin.php?page=eos-issues')); ?>'">
             <div class="eos-card-header">
                 <div class="eos-card-title">
                     <div class="eos-card-icon issues">⚠️</div>
                     <span><?php _e('Issues List', 'eos-manager'); ?></span>
                 </div>
-                <a href="<?php echo admin_url('admin.php?page=eos-issues'); ?>" class="eos-card-action">
+                <a href="<?php echo esc_url(admin_url('admin.php?page=eos-issues')); ?>" class="eos-card-action">
                     <?php _e('Manage', 'eos-manager'); ?> →
                 </a>
             </div>
             <div class="eos-card-stats">
                 <div class="eos-stat-item">
-                    <span class="eos-stat-number"><?php echo $issues_stats['high_priority']; ?></span>
+                    <span class="eos-stat-number"><?php echo esc_html($issues_stats['high_priority']); ?></span>
                     <span class="eos-stat-label"><?php _e('High Priority', 'eos-manager'); ?></span>
                 </div>
                 <div class="eos-stat-item">
-                    <span class="eos-stat-number"><?php echo $issues_stats['total_open']; ?></span>
+                    <span class="eos-stat-number"><?php echo esc_html($issues_stats['total_open']); ?></span>
                     <span class="eos-stat-label"><?php _e('Total Open', 'eos-manager'); ?></span>
                 </div>
             </div>
@@ -187,23 +187,23 @@ $upcoming_meetings = EOS_Meetings::get_upcoming(1);
         </div>
 
         <!-- People Analyzer Card -->
-        <div class="eos-dashboard-card" onclick="location.href='<?php echo admin_url('admin.php?page=eos-people'); ?>'">
+        <div class="eos-dashboard-card" onclick="location.href='<?php echo esc_url(admin_url('admin.php?page=eos-people')); ?>'">
             <div class="eos-card-header">
                 <div class="eos-card-title">
                     <div class="eos-card-icon people">👥</div>
                     <span><?php _e('People Analyzer', 'eos-manager'); ?></span>
                 </div>
-                <a href="<?php echo admin_url('admin.php?page=eos-people'); ?>" class="eos-card-action">
+                <a href="<?php echo esc_url(admin_url('admin.php?page=eos-people')); ?>" class="eos-card-action">
                     <?php _e('Assess', 'eos-manager'); ?> →
                 </a>
             </div>
             <div class="eos-card-stats">
                 <div class="eos-stat-item">
-                    <span class="eos-stat-number"><?php echo $people_stats['right_seat']; ?></span>
+                    <span class="eos-stat-number"><?php echo esc_html($people_stats['right_seat']); ?></span>
                     <span class="eos-stat-label"><?php _e('Right Seat', 'eos-manager'); ?></span>
                 </div>
                 <div class="eos-stat-item">
-                    <span class="eos-stat-number"><?php echo $people_stats['need_review']; ?></span>
+                    <span class="eos-stat-number"><?php echo esc_html($people_stats['need_review']); ?></span>
                     <span class="eos-stat-label"><?php _e('Need Review', 'eos-manager'); ?></span>
                 </div>
             </div>
@@ -212,7 +212,7 @@ $upcoming_meetings = EOS_Meetings::get_upcoming(1);
                 if ($people_stats['need_review'] > 0) {
                     printf(
                         __('%d people need GWC assessment.', 'eos-manager'),
-                        $people_stats['need_review']
+                        intval($people_stats['need_review'])
                     );
                 } else {
                     _e('All team members are in the right seats!', 'eos-manager');
@@ -222,13 +222,13 @@ $upcoming_meetings = EOS_Meetings::get_upcoming(1);
         </div>
 
         <!-- Vision/Traction Organizer Card -->
-        <div class="eos-dashboard-card" onclick="location.href='<?php echo admin_url('admin.php?page=eos-vto'); ?>'">
+        <div class="eos-dashboard-card" onclick="location.href='<?php echo esc_url(admin_url('admin.php?page=eos-vto')); ?>'">
             <div class="eos-card-header">
                 <div class="eos-card-title">
                     <div class="eos-card-icon vto">🎯</div>
                     <span><?php _e('Vision/Traction Organizer', 'eos-manager'); ?></span>
                 </div>
-                <a href="<?php echo admin_url('admin.php?page=eos-vto'); ?>" class="eos-card-action">
+                <a href="<?php echo esc_url(admin_url('admin.php?page=eos-vto')); ?>" class="eos-card-action">
                     <?php _e('Review', 'eos-manager'); ?> →
                 </a>
             </div>
@@ -242,7 +242,7 @@ $upcoming_meetings = EOS_Meetings::get_upcoming(1);
                     _e('Define your vision and organize for traction', 'eos-manager');
                 }
                 ?>
-                <br><small><?php printf(__('Last updated: %s', 'eos-manager'), EOS_VTO::get_last_updated()); ?></small>
+                  <br><small><?php printf(__('Last updated: %s', 'eos-manager'), esc_html(EOS_VTO::get_last_updated())); ?></small>
             </div>
         </div>
 
@@ -261,7 +261,7 @@ $upcoming_meetings = EOS_Meetings::get_upcoming(1);
             ?>
                 <div class="eos-activity-item">
                     <div class="eos-activity-icon <?php echo esc_attr($activity['type']); ?>">
-                        <?php echo $activity['icon']; ?>
+                    <?php echo wp_kses_post($activity['icon']); ?>
                     </div>
                     <div class="eos-activity-content">
                         <div class="eos-activity-text">
@@ -269,7 +269,10 @@ $upcoming_meetings = EOS_Meetings::get_upcoming(1);
                             <?php echo esc_html($activity['description']); ?>
                         </div>
                         <div class="eos-activity-time">
-                            <?php echo human_time_diff(strtotime($activity['created_at']), current_time('timestamp')) . ' ' . __('ago', 'eos-manager'); ?>
+                            <?php
+                            $time_diff = human_time_diff(strtotime($activity['created_at']), current_time('timestamp'));
+                            echo esc_html($time_diff) . ' ' . esc_html__('ago', 'eos-manager');
+                            ?>
                         </div>
                     </div>
                 </div>
@@ -319,7 +322,7 @@ $upcoming_meetings = EOS_Meetings::get_upcoming(1);
                 </div>
                 <div class="eos-form-field">
                     <label><?php _e('Date & Time', 'eos-manager'); ?></label>
-                    <input type="datetime-local" id="meetingDateTime" value="<?php echo date('Y-m-d\TH:i'); ?>">
+                    <input type="datetime-local" id="meetingDateTime" value="<?php echo esc_attr(date('Y-m-d\TH:i')); ?>">
                 </div>
             </div>
             <div class="eos-form-field">
@@ -399,7 +402,7 @@ function startL10Meeting() {
     const attendees = document.getElementById('meetingAttendees').value;
     
     // Redirect to full L10 meeting interface
-    window.location.href = `<?php echo admin_url('admin.php?page=eos-meetings&action=start'); ?>&title=${encodeURIComponent(title)}&datetime=${encodeURIComponent(dateTime)}&attendees=${encodeURIComponent(attendees)}`;
+      window.location.href = `<?php echo esc_url(admin_url('admin.php?page=eos-meetings&action=start')); ?>&title=${encodeURIComponent(title)}&datetime=${encodeURIComponent(dateTime)}&attendees=${encodeURIComponent(attendees)}`;
 }
 
 function scheduleL10Meeting() {
@@ -416,7 +419,7 @@ function saveRock() {
         due_date: document.getElementById('rockDueDate').value,
         description: document.getElementById('rockDescription').value,
         action: 'eos_save_rock',
-        nonce: '<?php echo wp_create_nonce('eos_nonce'); ?>'
+          nonce: '<?php echo esc_js(wp_create_nonce('eos_nonce')); ?>'
     };
     
     jQuery.post(ajaxurl, rockData, function(response) {

--- a/admin/views/issues.php
+++ b/admin/views/issues.php
@@ -1,0 +1,12 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+$issues = EOS_Issues::get_issues();
+?>
+<div class="wrap">
+    <h1><?php esc_html_e('Issues', 'eos-manager'); ?></h1>
+    <p><?php printf(esc_html__('Total Issues: %d', 'eos-manager'), count($issues)); ?></p>
+</div>
+

--- a/admin/views/meetings.php
+++ b/admin/views/meetings.php
@@ -1,0 +1,12 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+$meetings = EOS_Meetings::get_meetings();
+?>
+<div class="wrap">
+    <h1><?php esc_html_e('L10 Meetings', 'eos-manager'); ?></h1>
+    <p><?php printf(esc_html__('Total Meetings: %d', 'eos-manager'), count($meetings)); ?></p>
+</div>
+

--- a/admin/views/rocks.php
+++ b/admin/views/rocks.php
@@ -1,0 +1,12 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+$rocks = EOS_Rocks::get_rocks();
+?>
+<div class="wrap">
+    <h1><?php esc_html_e('Rocks', 'eos-manager'); ?></h1>
+    <p><?php printf(esc_html__('Total Rocks: %d', 'eos-manager'), count($rocks)); ?></p>
+</div>
+

--- a/admin/views/scorecard.php
+++ b/admin/views/scorecard.php
@@ -1,0 +1,12 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+$metrics = EOS_Scorecard::get_metrics();
+?>
+<div class="wrap">
+    <h1><?php esc_html_e('Scorecard', 'eos-manager'); ?></h1>
+    <p><?php printf(esc_html__('Total Metrics: %d', 'eos-manager'), count($metrics)); ?></p>
+</div>
+

--- a/eos-manager.php
+++ b/eos-manager.php
@@ -62,11 +62,8 @@ class EOS_Manager {
         // Add EOS quick links to admin bar
         add_action('admin_bar_menu', array($this, 'add_admin_bar_links'), 100);
         
-        // AJAX handlers
-        add_action('wp_ajax_eos_save_rock', array($this, 'ajax_save_rock'));
-        add_action('wp_ajax_eos_save_issue', array($this, 'ajax_save_issue'));
+        // AJAX handlers handled by module classes except scorecard
         add_action('wp_ajax_eos_save_scorecard', array($this, 'ajax_save_scorecard'));
-        add_action('wp_ajax_eos_save_meeting', array($this, 'ajax_save_meeting'));
     }
     
     /**
@@ -301,66 +298,28 @@ class EOS_Manager {
     }
     
     /**
-     * AJAX handler for saving rocks
-     */
-    public function ajax_save_rock() {
-        check_ajax_referer('eos_nonce', 'nonce');
-        
-        if (!current_user_can('manage_options')) {
-            wp_die('Unauthorized');
-        }
-        
-        $rock_data = $_POST['rock_data'];
-        $result = EOS_Rocks::save_rock($rock_data);
-        
-        wp_send_json($result);
-    }
-    
-    /**
-     * AJAX handler for saving issues
-     */
-    public function ajax_save_issue() {
-        check_ajax_referer('eos_nonce', 'nonce');
-        
-        if (!current_user_can('manage_options')) {
-            wp_die('Unauthorized');
-        }
-        
-        $issue_data = $_POST['issue_data'];
-        $result = EOS_Issues::save_issue($issue_data);
-        
-        wp_send_json($result);
-    }
-    
-    /**
      * AJAX handler for saving scorecard
      */
     public function ajax_save_scorecard() {
         check_ajax_referer('eos_nonce', 'nonce');
-        
+
         if (!current_user_can('manage_options')) {
-            wp_die('Unauthorized');
+            wp_send_json_error(__('Unauthorized', 'eos-manager'));
         }
-        
-        $scorecard_data = $_POST['scorecard_data'];
-        $result = EOS_Scorecard::save_metrics($scorecard_data);
-        
-        wp_send_json($result);
-    }
-    
-    /**
-     * AJAX handler for saving meeting data
-     */
-    public function ajax_save_meeting() {
-        check_ajax_referer('eos_nonce', 'nonce');
-        
-        if (!current_user_can('manage_options')) {
-            wp_die('Unauthorized');
+
+        $scorecard_data = isset($_POST['scorecard_data']) ? wp_unslash($_POST['scorecard_data']) : array();
+
+        if (!is_array($scorecard_data)) {
+            wp_send_json_error(__('Invalid data.', 'eos-manager'));
         }
-        
-        $meeting_data = $_POST['meeting_data'];
-        $result = EOS_Meetings::save_meeting($meeting_data);
-        
+
+        $sanitized = array();
+        foreach ($scorecard_data as $key => $value) {
+            $sanitized[sanitize_key($key)] = is_array($value) ? array_map('sanitize_text_field', $value) : sanitize_text_field($value);
+        }
+
+        $result = EOS_Scorecard::save_metrics($sanitized);
+
         wp_send_json($result);
     }
 }
@@ -439,4 +398,3 @@ function eos_shortcode($atts) {
 }
 add_shortcode('eos', 'eos_shortcode');
 
-?>

--- a/eos-manager.php
+++ b/eos-manager.php
@@ -50,9 +50,6 @@ class EOS_Manager {
      * Initialize WordPress hooks
      */
     private function init_hooks() {
-        register_activation_hook(__FILE__, array($this, 'activate'));
-        register_deactivation_hook(__FILE__, array($this, 'deactivate'));
-        
         add_action('init', array($this, 'init'));
         add_action('admin_menu', array($this, 'add_admin_menu'));
         add_action('admin_enqueue_scripts', array($this, 'enqueue_admin_scripts'));
@@ -85,7 +82,10 @@ class EOS_Manager {
     /**
      * Plugin activation
      */
-    public function activate() {
+    public static function activate() {
+        // Ensure database class is available
+        require_once EOS_MANAGER_PLUGIN_DIR . 'includes/class-eos-database.php';
+
         // Create database tables
         EOS_Database::create_tables();
         
@@ -100,7 +100,7 @@ class EOS_Manager {
     /**
      * Plugin deactivation
      */
-    public function deactivate() {
+    public static function deactivate() {
         // Clean up scheduled events
         wp_clear_scheduled_hook('eos_daily_scorecard_reminder');
         wp_clear_scheduled_hook('eos_weekly_l10_reminder');
@@ -323,6 +323,10 @@ class EOS_Manager {
         wp_send_json($result);
     }
 }
+
+// Register activation and deactivation hooks
+register_activation_hook(__FILE__, array('EOS_Manager', 'activate'));
+register_deactivation_hook(__FILE__, array('EOS_Manager', 'deactivate'));
 
 // Initialize the plugin
 add_action('plugins_loaded', array('EOS_Manager', 'get_instance'));

--- a/includes/class-eos-database.php
+++ b/includes/class-eos-database.php
@@ -241,15 +241,18 @@ class EOS_Database {
         );
         
         foreach ($default_sections as $section => $content) {
-            $wpdb->insert(
-                $table_vto,
-                array(
-                    'section' => $section,
-                    'content' => $content,
-                    'updated_by' => get_current_user_id()
-                ),
-                array('%s', '%s', '%d')
-            );
+            $exists = $wpdb->get_var($wpdb->prepare("SELECT id FROM $table_vto WHERE section = %s", $section));
+            if (!$exists) {
+                $wpdb->insert(
+                    $table_vto,
+                    array(
+                        'section' => $section,
+                        'content' => $content,
+                        'updated_by' => get_current_user_id()
+                    ),
+                    array('%s', '%s', '%d')
+                );
+            }
         }
     }
     

--- a/includes/class-eos-database.php
+++ b/includes/class-eos-database.php
@@ -308,11 +308,9 @@ class EOS_Database {
      */
     public static function maybe_update_db() {
         $current_db_version = get_option('eos_manager_db_version', '0');
-        
+
         if (version_compare($current_db_version, '1.0', '<')) {
             self::create_tables();
         }
     }
 }
-
-?>

--- a/includes/class-eos-integrations.php
+++ b/includes/class-eos-integrations.php
@@ -63,4 +63,3 @@ class EOS_Integrations {
         return !is_wp_error($response);
     }
 }
-?>

--- a/includes/class-eos-issues.php
+++ b/includes/class-eos-issues.php
@@ -598,5 +598,3 @@ class EOS_Issues {
         wp_send_json($result);
     }
 }
-
-?>

--- a/includes/class-eos-meetings.php
+++ b/includes/class-eos-meetings.php
@@ -644,5 +644,3 @@ class EOS_Meetings {
         wp_send_json(array('success' => true, 'meet_link' => $meet_link));
     }
 }
-
-?>

--- a/includes/class-eos-people.php
+++ b/includes/class-eos-people.php
@@ -510,7 +510,7 @@ class EOS_People {
                 $activity_data['icon'] = '👥';
                 break;
             case 'updated':
-                $activity_data['description'] = sprintf(__'Team member "%s" was updated', 'eos-manager'), $person_name);
+                $activity_data['description'] = sprintf(__('Team member "%s" was updated', 'eos-manager'), $person_name);
                 $activity_data['icon'] = '✏️';
                 break;
             case 'gwc_updated':
@@ -601,5 +601,3 @@ class EOS_People {
         wp_send_json($result);
     }
 }
-
-?>

--- a/includes/class-eos-rest-api.php
+++ b/includes/class-eos-rest-api.php
@@ -694,5 +694,3 @@ class EOS_REST_API {
         );
     }
 }
-
-?>

--- a/includes/class-eos-rocks.php
+++ b/includes/class-eos-rocks.php
@@ -552,5 +552,3 @@ class EOS_Rocks {
         wp_send_json($result);
     }
 }
-
-?>

--- a/includes/class-eos-scorecard.php
+++ b/includes/class-eos-scorecard.php
@@ -641,5 +641,3 @@ class EOS_Scorecard {
         wp_send_json($result);
     }
 }
-
-?>

--- a/includes/class-eos-vto.php
+++ b/includes/class-eos-vto.php
@@ -85,4 +85,3 @@ class EOS_VTO {
         }
     }
 }
-?>


### PR DESCRIPTION
## Summary
- Remove duplicate AJAX handlers in `eos-manager.php` and sanitize remaining scorecard save endpoint
- Escape dynamic data in the dashboard view and add missing admin templates for scorecard, rocks, issues, and meetings
- Prevent duplicate VTO section inserts during activation

## Testing
- `php -l eos-manager.php`
- `php -l admin/views/dashboard.php`
- `php -l admin/views/scorecard.php`
- `php -l admin/views/rocks.php`
- `php -l admin/views/issues.php`
- `php -l admin/views/meetings.php`
- `php -l includes/class-eos-database.php`


------
https://chatgpt.com/codex/tasks/task_e_68a8ba06cc688324a8e1833aca8937e2